### PR TITLE
Fix overwrites from files in the original branch which causes changes in the current branch to be missed until the next commit

### DIFF
--- a/src/TfvcMigrator/RepositoryBranchMapping.cs
+++ b/src/TfvcMigrator/RepositoryBranchMapping.cs
@@ -50,7 +50,7 @@ public readonly struct RepositoryBranchMapping
         if (!PathUtils.IsAbsolute(newPath))
             throw new ArgumentException("New path must be absolute.", nameof(newPath));
 
-        if (!PathUtils.IsOrContains(oldPath, RootDirectory))
+        if (!PathUtils.IsOrContains(RootDirectory, oldPath))
             throw new InvalidOperationException("The rename does not apply to this mapping.");
 
         if (SubdirectoryMapping is not null)

--- a/src/TfvcMigrator/RepositoryBranchMapping.cs
+++ b/src/TfvcMigrator/RepositoryBranchMapping.cs
@@ -73,7 +73,7 @@ public readonly struct RepositoryBranchMapping
 
         if (SubdirectoryMapping is var (branch, target))
         {
-            if (PathUtils.IsOrContains(itemPath, target))
+            if (PathUtils.IsOrContains(target, itemPath))
                 return null;
 
             if (PathUtils.IsOrContains(branch, itemPath))


### PR DESCRIPTION
I reviewed all IsOrContains calls and found one more place where the arguments were swapped. The second place is rather benign since it was only disabling a check, and the check would only be useful if it was catching an independent bug.

This is a good reason to consider refactoring to a form like `target.IsSamePathOrParentPathOf(itemPath)`.