### PR TITLE
Enforce use of explicit StringComparison if the default is linguistic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -93,3 +93,6 @@ dotnet_diagnostic.SA1649.severity = none
 
 # Workaround for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3503
 dotnet_diagnostic.SA1010.severity = none
+
+dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.CA1310.severity = warning


### PR DESCRIPTION
Didn't necessitate any changes, but would be good to lock in.

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1309

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1310