### PR TITLE
Use two different error messages.

### DIFF
--- a/src/TfvcMigrator/Program.cs
+++ b/src/TfvcMigrator/Program.cs
@@ -261,12 +261,12 @@ public static class Program
                             }
                             else
                             {
-                                throw new InvalidOperationException("Should not be reachable. Should be a single changeset matching parent branch.");
+                                throw new InvalidOperationException($"None of the commits created for the parent changeset {parentChangeset} has the expected branch {parentBranch}.");
                             }
                         }
                         else
                         {
-                            throw new InvalidOperationException("Should not be reachable. Earlier code should have sorted topologically or failed.");
+                            throw new InvalidOperationException($"A commit should have been created for the parent changeset {parentChangeset} before reaching this point.");
                         }
                     }
 

--- a/src/TfvcMigrator/Program.cs
+++ b/src/TfvcMigrator/Program.cs
@@ -253,10 +253,16 @@ public static class Program
 
                     foreach (var (_, parentChangeset, parentBranch) in mappingState.AdditionalParents.Where(t => t.Branch == branch))
                     {
-                        if (commitsByChangeset.TryGetValue(parentChangeset, out var createdChangesets)
-                            && createdChangesets.SingleOrDefault(c => c.Branch == parentBranch).Commit is { } commit)
+                        if (commitsByChangeset.TryGetValue(parentChangeset, out var createdChangesets))
                         {
-                            parents.Add(commit);
+                            if (createdChangesets.SingleOrDefault(c => c.Branch == parentBranch).Commit is { } commit)
+                            {
+                                parents.Add(commit);
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException("Should not be reachable. Should be a single changeset matching parent branch.");
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
#28
Provide some more info about where it goes wrong.